### PR TITLE
xsec interpolation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ include(${Geant4_USE_FILE})
 
 add_library(G4DarkBreM SHARED
   src/G4DarkBreM/ElementXsecCache.cxx
+  src/G4DarkBreM/ElementXsecInterpolation.cxx
   src/G4DarkBreM/G4APrime.cxx
   src/G4DarkBreM/G4DarkBreMModel.cxx
   src/G4DarkBreM/G4DarkBremsstrahlung.cxx

--- a/app/simulate.cxx
+++ b/app/simulate.cxx
@@ -398,7 +398,7 @@ void usage() {
     "               distribution of dark brem vertices is sampled."
     "\n"
     "OPTIONS\n"
-    "  -h, --help    : print this usage and exit"
+    "  -h, --help    : print this usage and exit\n"
     "  --muons       : run using muons (without this flag, assumes electrons)\n"
     "  -m, --ap-mass : mass of the dark photon (A') in GeV (defaults to 0.1 for electrons and 1. for muons)\n"
     "  -d, --depth   : thickness of target in mm (defaults to 18 for electrons, 2000 for muons)\n"

--- a/app/simulate.cxx
+++ b/app/simulate.cxx
@@ -99,7 +99,7 @@ class APrimePhysics : public G4VPhysicsConstructor {
           library_path_, muons_)),
         false, /* only one per event */
         bias_, /* global bias */
-        true /* cache xsec */));
+        true /* interpolate xsec */));
   }
 };  // APrimePhysics
 

--- a/include/G4DarkBreM/ElementXsecInterpolation.h
+++ b/include/G4DarkBreM/ElementXsecInterpolation.h
@@ -58,32 +58,67 @@ class ElementXsecInterpolation {
    public:
     /**
      * Initialize the sample set with the two input vectors
+     *
+     * @note We assume that the input vectors are ordered properly
+     * i.e. init_x are ordered by their values and init_y are paired
+     * with their x.
+     *
+     * @param[in] init_x x values ordered by x
+     * @param[in] init_y corresponding y values
      */
     SampleSet(const std::vector<double>& init_x,
-              const std::vector<double>& inti_y);
+              const std::vector<double>& init_y);
 
     /**
      * Get the minimum x currently in sample set
+     * @return minimum x in sample set
      */
     const double& min() const;
 
     /**
      * Get the maximum x currently in sample set
+     * @return maximum x in sample set
      */
     const double& max() const;
 
     /**
      * prepend the sample set with the input point
+     * 
+     * We assume that the input x is less than the current
+     * minimum x. In debug build mode, this assumption is
+     * enforced by assert.
+     *
+     * @param[in] x new lowest x sample point
+     * @param[in] y corresponding y value
      */
     void prepend(double x, double y);
 
     /**
      * append the sample set with the input point
+     * 
+     * We assume that the input x is greater than the current
+     * maximum x. In debug build mode, this assumption is
+     * enforced by assert.
+     *
+     * @param[in] x new highest x sample point
+     * @param[in] y corresponding y value
      */
     void append(double x, double y);
 
     /**
      * Calculate an interpolation for the point x
+     *
+     * The interpolation is a quadratic interpolation over
+     * three points whose range encloses the requested sample x.
+     * The first such three points that satisfies this criteria
+     * is used, so this usually selects the three points where
+     * two points are below x and one above.
+     *
+     * @note We assume that the input x is within the range
+     * of the sample set. In debug build mode, this assumption
+     * is enforced with assert.
+     *
+     * @return interpolated value y for the input x
      */
     double interpolate(double x) const;
 

--- a/include/G4DarkBreM/ElementXsecInterpolation.h
+++ b/include/G4DarkBreM/ElementXsecInterpolation.h
@@ -1,0 +1,108 @@
+#ifndef G4DarkBREM_ELEMENTXSECINTERPOLATION_H
+#define G4DarkBREM_ELEMENTXSECINTERPOLATION_H
+
+#include <memory>
+
+#include "G4DarkBreM/PrototypeModel.h"
+
+namespace g4db {
+
+/**
+ * Interpolation of cross sections by element
+ *
+ * The interpolation method is a modified quadratic interpolation
+ * where the main modification is - since we have a way to calculate
+ * new sample points - we expand the set of sample points if a
+ * cross section is requested for a energy and/or element outside
+ * of our current sample range.
+ */
+class ElementXsecInterpolation {
+ public:
+  /**
+   * Default constructor
+   *
+   * Does nothing interesting, but no model for calculating cross section has
+   * been set. If interpolation is attempted with a default-constructed
+   * interpolator, an exception will be thrown.
+   */
+  ElementXsecInterpolation() = default;
+
+  /**
+   * Constructor with a model to calculate the cross section.
+   */
+  ElementXsecInterpolation(std::shared_ptr<PrototypeModel> model)
+      : model_{model} {}
+
+  /**
+   * Get the value of the cross section for the input variables.
+   *
+   * For the interpolation to be successful, we impose the kinematic
+   * limit immediately - i.e. if energy is less than twice the A'
+   * mass, the cross section is zero.
+   *
+   * @throws std::runtime_error if no model is available for calculating cross sections
+   * @param[in] energy Energy of incident lepton [MeV]
+   * @param[in] A atomic mass of element [atomic mass units]
+   * @param[in] Z atomic number of element [num protons]
+   * @returns cross section corresponding to the input parameters (including
+   * units Geant4 style)
+   */
+  G4double get(G4double energy, G4double A, G4double Z);
+
+ private:
+  /**
+   * A sample set is two parallel vectors limited to operate for 
+   * our interpolation goal
+   */
+  class SampleSet {
+   public:
+    /**
+     * Initialize the sample set with the two input vectors
+     */
+    SampleSet(const std::vector<double>& init_x,
+              const std::vector<double>& inti_y);
+
+    /**
+     * Get the minimum x currently in sample set
+     */
+    const double& min() const;
+
+    /**
+     * Get the maximum x currently in sample set
+     */
+    const double& max() const;
+
+    /**
+     * prepend the sample set with the input point
+     */
+    void prepend(double x, double y);
+
+    /**
+     * append the sample set with the input point
+     */
+    void append(double x, double y);
+
+    /**
+     * Calculate an interpolation for the point x
+     */
+    double interpolate(double x) const;
+
+   private:
+    /// x points
+    std::vector<double> x_;
+    /// y points
+    std::vector<double> y_;
+  };
+
+ private:
+  /// each element has its own set of sample points
+  std::map<int, SampleSet> the_samples_;
+
+  /// shared pointer to the model for calculating cross sections
+  std::shared_ptr<PrototypeModel> model_;
+
+};  // ElementXsecInterpolation
+
+}
+
+#endif

--- a/include/G4DarkBreM/G4DarkBremsstrahlung.h
+++ b/include/G4DarkBreM/G4DarkBremsstrahlung.h
@@ -13,6 +13,7 @@
 
 #include "G4DarkBreM/PrototypeModel.h"
 #include "G4DarkBreM/ElementXsecCache.h"
+#include "G4DarkBreM/ElementXsecInterpolation.h"
 
 class G4String;
 class G4ParticleDefinition;
@@ -50,6 +51,7 @@ class G4DarkBremsstrahlung : public G4VDiscreteProcess {
    * @param[in] the_model model to use for dark brem simulation
    * @param[in] only_one_per_event true if de-activating process after first dark brem
    * @param[in] global_bias bias xsec globally by this factor
+   * @param[in] interpolate_xsec true if we should interpolate cross sections over 10% energy differences
    * @param[in] cache_xsec true if we should cache xsecs at the MeV level of precision
    * @param[in] verbose_level level of verbosity to print for this process and model
    * @param[in] subtype subtype for this process distinct from other EM 
@@ -57,7 +59,8 @@ class G4DarkBremsstrahlung : public G4VDiscreteProcess {
    */
   G4DarkBremsstrahlung(std::shared_ptr<g4db::PrototypeModel> the_model,
       bool only_one_per_event = false, double global_bias = 1., 
-      bool cache_xsec = true, int verbose_level = 0, int subtype = 63);
+      bool interp_xsec = true, bool cache_xsec = false, 
+      int verbose_level = 0, int subtype = 63);
 
   /**
    * Destructor
@@ -173,6 +176,11 @@ class G4DarkBremsstrahlung : public G4VDiscreteProcess {
   double global_bias_;
 
   /**
+   * Should we interpolated over the computed cross sections?
+   */
+  bool interpolate_xsec_;
+
+  /**
    * Should we have a cache for the computed cross sections?
    */
   bool cache_xsec_;
@@ -186,6 +194,9 @@ class G4DarkBremsstrahlung : public G4VDiscreteProcess {
 
   /// Our instance of a cross section cache
   g4db::ElementXsecCache element_xsec_cache_;
+
+  /// Our instance of a cross section interpolation
+  g4db::ElementXsecInterpolation element_xsec_interpolation_;
 };  // G4DarkBremsstrahlung
 
 #endif

--- a/src/G4DarkBreM/ElementXsecInterpolation.cxx
+++ b/src/G4DarkBreM/ElementXsecInterpolation.cxx
@@ -5,7 +5,7 @@ namespace g4db {
 
 G4double ElementXsecInterpolation::get(G4double energy, G4double A, G4double Z) {
   static const double kinematic_min = 2*G4APrime::APrime()->GetPDGMass();
-  if (energy < kinematic_min) return 0;
+  if (energy <= kinematic_min) return 0;
   double x = energy - kinematic_min;
   /**
    * @note Implicit conversion to integer from the double form of Z.
@@ -105,11 +105,19 @@ void ElementXsecInterpolation::SampleSet::append(double x, double y) {
 }
 
 double ElementXsecInterpolation::SampleSet::interpolate(double x) const {
-  assert(x > x_.front() && x < x_.back());
+  assert((x >= x_.front() && x <= x_.back()));
+  if (x == x_.front()) {
+    return y_.front();
+  }
+  if (x == x_.back()) {
+    return y_.back();
+  }
   std::size_t i_0{0};
   for (; i_0 < x_.size()-2; ++i_0) {
     if (x > x_[i_0] and x < x_[i_0+2]) {
       break;
+    } else if (x == x_[i_0]) {
+      return y_[i_0];
     }
   }
   double x_0{x_[i_0  ]}, y_0{y_[i_0  ]},

--- a/src/G4DarkBreM/ElementXsecInterpolation.cxx
+++ b/src/G4DarkBreM/ElementXsecInterpolation.cxx
@@ -1,0 +1,125 @@
+#include "G4DarkBreM/ElementXsecInterpolation.h"
+#include "G4DarkBreM/G4APrime.h"
+
+namespace g4db {
+
+G4double ElementXsecInterpolation::get(G4double energy, G4double A, G4double Z) {
+  static const double kinematic_min = 2*G4APrime::APrime()->GetPDGMass();
+  if (energy < kinematic_min) return 0;
+  double x = energy - kinematic_min;
+  /**
+   * @note Implicit conversion to integer from the double form of Z.
+   * This may not function properly if users have a custom element that
+   * is an averaged Z, but since elements close in Z behave similarly, 
+   * this may not matter either.
+   */
+  int Z_key = Z;
+
+  auto sample_set = the_samples_.find(Z_key);
+  if (sample_set == the_samples_.end()) {
+    if (model_.get() == nullptr) {
+      throw std::runtime_error(
+                      "ElementXsecInterpolation not given a model to calculate cross "
+                      "sections with.");
+    }
+    /**
+     * When there is no entry for an element yet, we
+     * initialize the samples by calculating the cross
+     * section for the requested energy and a sample above
+     * and below.
+     */
+    double xsec = model_->ComputeCrossSectionPerAtom(energy, A, Z);
+    std::vector<double> init_x{x/2, x, 2*x};
+    std::vector<double> init_y{ 
+      model_->ComputeCrossSectionPerAtom(x/2+kinematic_min, A, Z),
+      xsec,
+      model_->ComputeCrossSectionPerAtom(2*x+kinematic_min, A, Z)
+    };
+    the_samples_.emplace(std::piecewise_construct,
+        std::forward_as_tuple(Z_key),
+        std::forward_as_tuple(init_x, init_y));
+    return xsec;
+  } else if (x < sample_set->second.min()) {
+    /**
+     * When the requested energy is below the lowest sample point,
+     * we determine two more samples. One at the requested energy
+     * and one below it.
+     */
+    double xsec = model_->ComputeCrossSectionPerAtom(energy, A, Z);
+    sample_set->second.prepend(x, xsec);
+    sample_set->second.prepend(
+        x/2, 
+        model_->ComputeCrossSectionPerAtom(x/2+kinematic_min, A, Z)
+        );
+    return xsec;
+  } else if (x > sample_set->second.max()) {
+    /**
+     * When the requested energy is above the highest sample point,
+     * we determine two more samples. One at the requested energy
+     * and one above it.
+     */
+    double xsec = model_->ComputeCrossSectionPerAtom(energy, A, Z);
+    sample_set->second.append(x, xsec);
+    sample_set->second.append(
+        2*x, 
+        model_->ComputeCrossSectionPerAtom(2*x+kinematic_min, A, Z)
+        );
+    return xsec;
+  } else {
+    /**
+     * When the requested energy is within the range set by our
+     * samples, we do a quadratic interpolation using the three
+     * points that enclose the requested energy.
+     *
+     * We do the interpolation with the _first_ set of three points
+     * that encloses the requested energy, so this prefers the point
+     * set that has two samples below and one above.
+     */
+    return sample_set->second.interpolate(x);
+  }
+}
+
+ElementXsecInterpolation::SampleSet::SampleSet(const std::vector<double>& x, 
+    const std::vector<double>& y) : x_{x}, y_{y} {
+  assert(x_.size() == y_.size());
+}
+
+const double& ElementXsecInterpolation::SampleSet::min() const {
+  return x_.front();
+}
+
+const double& ElementXsecInterpolation::SampleSet::max() const {
+  return x_.back();
+}
+
+void ElementXsecInterpolation::SampleSet::prepend(double x, double y) {
+  assert(x < x_.front());
+  x_.insert(x_.begin(), x);
+  y_.insert(y_.begin(), y);
+}
+
+void ElementXsecInterpolation::SampleSet::append(double x, double y) {
+  assert(x > x_.back());
+  x_.push_back(x);
+  y_.push_back(y);
+}
+
+double ElementXsecInterpolation::SampleSet::interpolate(double x) const {
+  assert(x > x_.front() && x < x_.back());
+  std::size_t i_0{0};
+  for (; i_0 < x_.size()-2; ++i_0) {
+    if (x > x_[i_0] and x < x_[i_0+2]) {
+      break;
+    }
+  }
+  double x_0{x_[i_0  ]}, y_0{y_[i_0  ]},
+         x_1{x_[i_0+1]}, y_1{y_[i_0+1]},
+         x_2{x_[i_0+2]}, y_2{y_[i_0+2]};
+  return (
+       (x - x_1)*(x - x_2)/(x_0 - x_2)/(x_0 - x_1)*y_0
+      +(x - x_0)*(x - x_2)/(x_1 - x_2)/(x_1 - x_0)*y_1
+      +(x - x_0)*(x - x_1)/(x_2 - x_0)/(x_2 - x_1)*y_2
+      );
+}
+
+}


### PR DESCRIPTION
The actual interpolation method is rather simple - we choose the three nearest points and then use a quadratic interpolation scheme. This makes the interpolation extremely fast.

Following Michael R's advice, I have the initial table of energy/cross section values be determined upon the first "table-miss" so there isn't much of a speed up in low-event-number runs; however, constructing this table immediately allows for a majority of following cross section calls to "hit" the interpolation instead of the full calculation, saving a lot of time.

My validation is copied below, showing that the interpolation is accurate. I still need to integrate this into the simulation so that I can check its speed.

## To Do
- [x] Integrate into simulation
- [x] Check speed of interpolation vs cache
- [x] Write dump method so people can inspect the sample points being used in the interpolation

---

```python
import pandas

%matplotlib inline
import matplotlib.pyplot as plt
import mplhep
plt.style.use(mplhep.style.ROOT)
```

# Validation of Interpolation
I want to compare the full cross section calculation to the interpolation. For this to function, I do the full calculation at a set of points and then run the interpolation through those points at a higher granularity so that we see the interpolation do its "magic".

After building this branch, I ran the following bash script to calculate the necessary CSV data files.
```bash
for method in fullww iww hiww; do
  for mass in 1 0.1 0.01 0.001; do
    ./g4db-xsec-calc --apmass ${mass} --method ${method} --energy 0 4 0.1 --output no-interpo-${mass}GeV-${method}-xsec.csv
    ./g4db-xsec-calc --apmass ${mass} --method ${method} --energy 0 4 0.01 --interpolation --output interpo-${mass}GeV-${method}-xsec.csv
  done
done
```

```python
for mass in [1,0.1,0.01,0.001] :
    (raw, ratio) = plt.gcf().subplots(
        ncols = 1, nrows = 2, 
        sharex = 'col', gridspec_kw=dict(height_ratios = [3,1])
    )
    plt.subplots_adjust(hspace=0)

    for method in ['full','i','hi'] :
        no_interpo = pandas.read_csv(f'no-interpo-{method}ww-{mass}GeV-xsec.csv')
        interpo    = pandas.read_csv(f'interpo-{method}ww-{mass}GeV-xsec.csv')
        raw.plot(interpo['Energy [MeV]'], interpo['Xsec [pb]'], label=f'{method} interpo')
        raw.scatter(no_interpo['Energy [MeV]'], no_interpo['Xsec [pb]'], label=f'{method} nointerpo')
        # since the interpolated data set and the non-interpolated data sets have different data points
        #   we use the non-interpolated energies to try to find a selection for the interpolated ones
        # also since we are dividing by no_interpo, we select only those energies with a positive xsec
        selection = interpo['Energy [MeV]'].isin(no_interpo[no_interpo['Xsec [pb]']>0]['Energy [MeV]'])
        ratio.plot(
            interpo[selection]['Energy [MeV]'], 
            interpo[selection]['Xsec [pb]'].to_numpy()/no_interpo[no_interpo['Xsec [pb]']>0]['Xsec [pb]'].to_numpy()
        )
    raw.legend(
        title=f'$m_A = {mass}$ GeV'
    )
    raw.set_ylabel('Xsec [pb]')
    ratio.set_ylabel('Interp Acc')
    ratio.set_xlabel('Energy [MeV]')
    plt.show()
```
![output_2_0](https://user-images.githubusercontent.com/31970302/232542563-314b5a41-44b0-4d29-816b-8f727d63e353.png)
![output_2_1](https://user-images.githubusercontent.com/31970302/232542567-4fd7ad04-9017-4fb2-9c5a-5153fb2d4e61.png)
![output_2_2](https://user-images.githubusercontent.com/31970302/232542569-468477b1-6beb-4595-9b70-a2d03aeaa22d.png)
![output_2_3](https://user-images.githubusercontent.com/31970302/232542571-7db4ea10-5682-4062-8570-c618c3b32afc.png)
